### PR TITLE
Scrape full Kino Aero program into the calendar

### DIFF
--- a/src/kino/models.py
+++ b/src/kino/models.py
@@ -43,16 +43,20 @@ class Screening(BaseModel):
         )
 
 
-class SecretScreening(BaseModel):
+class AeroScreening(BaseModel):
+    """A Kino Aero screening without matching CSFD data (e.g. Aero naslepo
+    or a special event). Carries its own emoji: 😎 for naslepo, ✈️ otherwise."""
+
     cinema: Cinema
     title: str
     screening_url: str
     starts_at: datetime
     ends_at: datetime
+    emoji: str
 
     def to_ical(self, flags: dict[str, str]) -> Event:
         return Event(
-            name=f"😎 {self.title}",
+            name=f"{self.emoji} {self.title}",
             begin=self.starts_at,
             end=self.ends_at,
             location=str(self.cinema),

--- a/src/kino/scraper.py
+++ b/src/kino/scraper.py
@@ -270,6 +270,7 @@ async def aero_handler(context: BeautifulSoupCrawlingContext):
             Request.from_url(
                 AERO_API_FILM_URL,
                 method="POST",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
                 payload=urlencode({"pr": projection, "_locale": "cs"}).encode(),
                 label="aero_film",
                 unique_key=projection,  # all screenings share the api_film URL

--- a/src/kino/scraper.py
+++ b/src/kino/scraper.py
@@ -88,9 +88,11 @@ async def scrape() -> list[Screening | AeroScreening]:
 def pair(
     base: list[Screening], aero: list[dict[str, Any]]
 ) -> list[Screening | AeroScreening]:
-    # Keep everything from the CSFD base, then add Aero screenings which aren't
-    # already there. A screening is the same when it's the same film (CSFD ID)
-    # at the same time.
+    """Merge Aero screenings into the CSFD base.
+
+    Screenings already in the base (the same CSFD film at the same time) are
+    kept as they are; the rest are added as generic Aero screenings.
+    """
     known = {(csfd_film_id(s.film_url), s.starts_at) for s in base}
     screenings: list[Screening | AeroScreening] = list(base)
     for item in aero:
@@ -100,7 +102,7 @@ def pair(
             screening_url=item["screening_url"],
             starts_at=item["starts_at"],
             ends_at=item["ends_at"],
-            emoji="😎" if "naslepo" in item["title"].lower() else "✈️",
+            emoji=item["emoji"],
         )
         if (item["csfd_id"], screening.starts_at) not in known:
             screenings.append(screening)
@@ -108,6 +110,7 @@ def pair(
 
 
 def csfd_film_id(url: str) -> str | None:
+    """Extract the numeric CSFD film ID from a CSFD film URL, if present."""
     if match := CSFD_FILM_ID_RE.search(url):
         return match.group(1)
     return None
@@ -262,6 +265,7 @@ def from_user_data(user_data: dict[str, Any]) -> TimeTableDict:
 
 @router.handler("aero")
 async def aero_handler(context: BeautifulSoupCrawlingContext):
+    """Enqueue an api_film detail lookup for each screening in the program."""
     context.log.info(f"Aero program {context.request.url}")
     requests = []
     for projection, screening in parse_aero_program(context.soup):
@@ -281,6 +285,11 @@ async def aero_handler(context: BeautifulSoupCrawlingContext):
 
 
 def parse_aero_program(soup: Tag) -> list[tuple[str, dict[str, str]]]:
+    """Extract (projection ID, screening) pairs from a Kino Aero program page.
+
+    Aero naslepo screenings are recognised by their "Naslepo" cycle tag and get
+    the 😎 emoji; everything else gets the generic Aero ✈️.
+    """
     program = []
     for row in soup.select(".program__info-row"):
         script = row.select_one('script[type="application/ld+json"]')
@@ -288,6 +297,7 @@ def parse_aero_program(soup: Tag) -> list[tuple[str, dict[str, str]]]:
         if not (script and script.string and element):
             continue  # e.g. sold out or cancelled screenings
         data = json.loads(script.string)
+        tags = {tag.text.strip() for tag in row.select(".program__tag")}
         program.append(
             (
                 str(element["data-projection"]),
@@ -296,6 +306,7 @@ def parse_aero_program(soup: Tag) -> list[tuple[str, dict[str, str]]]:
                     "screening_url": data["url"],
                     "starts_at": data["startDate"],
                     "ends_at": data["endDate"],
+                    "emoji": "😎" if "Naslepo" in tags else "✈️",
                 },
             )
         )
@@ -304,6 +315,7 @@ def parse_aero_program(soup: Tag) -> list[tuple[str, dict[str, str]]]:
 
 @router.handler("aero_film")
 async def aero_film_handler(context: BeautifulSoupCrawlingContext):
+    """Collect a single Aero screening together with its CSFD ID (if any)."""
     context.log.info(f"Aero film {context.request.user_data['title']}")
     await context.push_data(
         {
@@ -311,13 +323,17 @@ async def aero_film_handler(context: BeautifulSoupCrawlingContext):
             "screening_url": context.request.user_data["screening_url"],
             "starts_at": context.request.user_data["starts_at"],
             "ends_at": context.request.user_data["ends_at"],
+            "emoji": context.request.user_data["emoji"],
             "csfd_id": parse_aero_csfd_id(context.soup),
         }
     )
 
 
 def parse_aero_csfd_id(soup: Tag) -> str | None:
-    # Missing link means Aero naslepo or a special event without a CSFD page.
+    """Return the CSFD film ID an Aero film detail links to, if any.
+
+    A missing link means Aero naslepo or a special event without a CSFD page.
+    """
     if link := soup.select_one('a[href*="csfd.cz/film/"]'):
         return csfd_film_id(str(link["href"]))
     return None

--- a/src/kino/scraper.py
+++ b/src/kino/scraper.py
@@ -3,23 +3,27 @@ import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from typing import Any, TypedDict
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 from zoneinfo import ZoneInfo
 
 from bs4 import Tag
 from crawlee import Request
 from crawlee.crawlers import BeautifulSoupCrawler, BeautifulSoupCrawlingContext
 from crawlee.router import Router
-from pydantic import RootModel, ValidationError
+from pydantic import RootModel
 
-from kino.models import Cinema, Screening, SecretScreening
+from kino.models import AeroScreening, Cinema, Screening
 
 
 PRAGUE_TZ = ZoneInfo("Europe/Prague")
 
 CSFD_URL = "https://www.csfd.cz/kino/1-praha/?period=week"
 
-AERO_NASLEPO_URL = "https://kinoaero.cz/?cinema=1&sort=sort-by-data&cycle=naslepo"
+AERO_PROGRAM_URL = "https://kinoaero.cz/?cinema=1&sort=sort-by-data"
+
+AERO_API_FILM_URL = "https://kinoaero.cz/api_film"
+
+CSFD_FILM_ID_RE = re.compile(r"/film/(\d+)")
 
 CINEMAS = {
     "Praha - Cinema City Flora": Cinema.FLORA,
@@ -59,25 +63,54 @@ TimeTable = RootModel[TimeTableDict]
 router = Router[BeautifulSoupCrawlingContext]()
 
 
-async def scrape() -> list[Screening | SecretScreening]:
+async def scrape() -> list[Screening | AeroScreening]:
     crawler = BeautifulSoupCrawler(request_handler=router)
     await crawler.run(
         [
             CSFD_URL,
-            Request.from_url(AERO_NASLEPO_URL, label="aero_naslepo"),
+            Request.from_url(AERO_PROGRAM_URL, label="aero"),
         ]
     )
     if errors_count := crawler.statistics.state.requests_failed:
         raise RuntimeError(f"Failed requests: {errors_count}")
+
     dataset = await crawler.get_dataset()
-    return [create_screening(item) async for item in dataset.iterate_items()]
+    base: list[Screening] = []
+    aero: list[dict[str, Any]] = []
+    async for item in dataset.iterate_items():
+        if "film_url" in item:
+            base.append(Screening(**item))
+        else:
+            aero.append(item)
+    return pair(base, aero)
 
 
-def create_screening(data: dict[str, Any]) -> Screening | SecretScreening:
-    try:
-        return Screening(**data)
-    except ValidationError:
-        return SecretScreening(**data)
+def pair(
+    base: list[Screening], aero: list[dict[str, Any]]
+) -> list[Screening | AeroScreening]:
+    # Keep everything from the CSFD base, then add Aero screenings which aren't
+    # already there. A screening is the same when it's the same film (CSFD ID)
+    # at the same time.
+    known = {(csfd_film_id(s.film_url), s.starts_at) for s in base}
+    screenings: list[Screening | AeroScreening] = list(base)
+    for item in aero:
+        screening = AeroScreening(
+            cinema=Cinema.AERO,
+            title=item["title"],
+            screening_url=item["screening_url"],
+            starts_at=item["starts_at"],
+            ends_at=item["ends_at"],
+            emoji="😎" if "naslepo" in item["title"].lower() else "✈️",
+        )
+        if (item["csfd_id"], screening.starts_at) not in known:
+            screenings.append(screening)
+    return screenings
+
+
+def csfd_film_id(url: str) -> str | None:
+    if match := CSFD_FILM_ID_RE.search(url):
+        return match.group(1)
+    return None
 
 
 @router.default_handler
@@ -227,23 +260,63 @@ def from_user_data(user_data: dict[str, Any]) -> TimeTableDict:
     return TimeTable.model_validate_json(user_data["timetable"]).model_dump()
 
 
-@router.handler("aero_naslepo")
-async def aero_naslepo_handler(context: BeautifulSoupCrawlingContext):
-    context.log.info(f"Aero naslepo {context.request.url}")
-    for script in context.soup.select("#program .program script"):
-        if json_ld := script.string:
-            data = json.loads(json_ld)
-            starts_at = datetime.fromisoformat(data["startDate"])
-            screening_url = data["url"]
-            context.log.info(f"Screening {starts_at} {screening_url}")
-            await context.push_data(
-                {
-                    "title": "Aero naslepo",
-                    "screening_url": screening_url,
-                    "starts_at": starts_at,
-                    "ends_at": datetime.fromisoformat(data["endDate"]),
-                    "cinema": Cinema.AERO,
-                }
+@router.handler("aero")
+async def aero_handler(context: BeautifulSoupCrawlingContext):
+    context.log.info(f"Aero program {context.request.url}")
+    requests = []
+    for projection, screening in parse_aero_program(context.soup):
+        context.log.info(f"Screening {screening['starts_at']} {projection}")
+        requests.append(
+            Request.from_url(
+                AERO_API_FILM_URL,
+                method="POST",
+                payload=urlencode({"pr": projection, "_locale": "cs"}).encode(),
+                label="aero_film",
+                unique_key=projection,  # all screenings share the api_film URL
+                user_data=screening,
             )
-        else:
-            raise UnexpectedStructureError("No JSON-LD found")
+        )
+    await context.add_requests(requests)
+
+
+def parse_aero_program(soup: Tag) -> list[tuple[str, dict[str, str]]]:
+    program = []
+    for row in soup.select(".program__info-row"):
+        script = row.select_one('script[type="application/ld+json"]')
+        element = row.select_one("[data-projection]")
+        if not (script and script.string and element):
+            continue  # e.g. sold out or cancelled screenings
+        data = json.loads(script.string)
+        program.append(
+            (
+                str(element["data-projection"]),
+                {
+                    "title": data["name"],
+                    "screening_url": data["url"],
+                    "starts_at": data["startDate"],
+                    "ends_at": data["endDate"],
+                },
+            )
+        )
+    return program
+
+
+@router.handler("aero_film")
+async def aero_film_handler(context: BeautifulSoupCrawlingContext):
+    context.log.info(f"Aero film {context.request.user_data['title']}")
+    await context.push_data(
+        {
+            "title": context.request.user_data["title"],
+            "screening_url": context.request.user_data["screening_url"],
+            "starts_at": context.request.user_data["starts_at"],
+            "ends_at": context.request.user_data["ends_at"],
+            "csfd_id": parse_aero_csfd_id(context.soup),
+        }
+    )
+
+
+def parse_aero_csfd_id(soup: Tag) -> str | None:
+    # Missing link means Aero naslepo or a special event without a CSFD page.
+    if link := soup.select_one('a[href*="csfd.cz/film/"]'):
+        return csfd_film_id(str(link["href"]))
+    return None

--- a/tests/fixtures/aero_film.html
+++ b/tests/fixtures/aero_film.html
@@ -1,0 +1,11 @@
+<div class="modal-body__buttons">
+<a class="btn btn-outline-secondary" href="https://www.csfd.cz/film/1703542" target="_blank">
+                    ČSFD
+                </a>
+<a class="btn btn-outline-secondary" href="https://www.imdb.com/title/tt31514146/" target="_blank">
+                    IMDB
+                </a>
+<a class="btn btn-outline-secondary" href="https://letterboxd.com/film/i-swear/" target="_blank">
+                    Letterboxd
+                </a>
+</div>

--- a/tests/fixtures/aero_film_no_csfd.html
+++ b/tests/fixtures/aero_film_no_csfd.html
@@ -1,0 +1,14 @@
+
+<div class="modal-body__left" data-movie-desc="Záznam derniéry legendární inscenace podle povídek Irvina Welshe z prken Dejvického divadla.
+
+Když se vá" data-page-title="Dejvické divadlo: Ucpanej systém – hraje se v kině Aero">
+<div class="d-flex show-on-mobile" data-get-height="">
+<h3>Dejvické divadlo: Ucpanej systém</h3>
+<button aria-label="Close" class="btn modal-content__close-btn" data-bs-dismiss="modal" type="button">
+<svg viewbox="0 0 20 20" x="0px" y="0px">
+<path d="M11,10l2.6-2.6l-1-1L10,9L7.4,6.4l-1,1L9,10l-2.6,2.6l1,1L10,11l2.6,2.6l1-1L11,10z M18.3,10c0,0.9-0.1,1.8-0.4,2.6
+                    c-0.3,0.8-0.7,1.6-1.2,2.3c-0.5,0.7-1.1,1.3-1.8,1.8c-0.7,0.5-1.5,0.9-2.3,1.2c-0.8,0.3-1.7,0.4-2.6,0.4c-0.9,0-1.8-0.1-2.6-0.4
+                    c-0.8-0.3-1.6-0.7-2.3-1.2c-0.7-0.5-1.3-1.1-1.8-1.8c-0.5-0.7-0.9-1.5-1.2-2.3c-0.3-0.8-0.4-1.7-0.4-2.6c0-0.9,0.1-1.8,0.4-2.6
+                    c0.3-0.8,0.7-1.6,1.2-2.3c0.5-0.7,1.1-1.3,1.8-1.8c0.7-0.5,1.5-0.9,2.3-1.2C8.2,1.8,9.1,1.7,10,1.7c0.9,0,1.8,0.1,2.6,0.4
+                    c0.8,0.3,1.6,0.7,2.3,1.2c0.7,0.5,1.3,1.1,1.8,1.8c0.5,0.7,0.9,1.5,1.2,2.3C18.2,8.2,18.3,9.1,18.3,10 M19.6,10c0-1.1-0.2-2.1-0.5-3
+                    c-0.3-1-0.8-1.8

--- a/tests/fixtures/aero_program.html
+++ b/tests/fixtures/aero_program.html
@@ -1,0 +1,166 @@
+<div id="program">
+<div class="program__info-row program__info-row--running">
+<div class="program__info-row-left">
+<div class="program__shared-hover program__shared-hover--kino-aero">
+<div class="program__info-row-left-top" data-bs-target="#projection-detail-modal" data-bs-toggle="modal" data-movie-desc="Máte rádi překvapení? Věříte dramaturgům kina Aero, že vás dokáží příjemně překvapit? Když přijmete na&amp;s" data-page-title="Aero naslepo – hraje se v kině Aero" data-projection="50303">
+<div class="program__hour">20:30</div>
+<div class="program__place program__place--desktop">
+<span>Aero</span><br/>
+                                        Kinosál                                    </div>
+<div class="program__place program__place--mobile">
+<span>Aero</span><br/>
+</div>
+</div>
+<div class="program__movie-name" data-bs-target="#projection-detail-modal" data-bs-toggle="modal" data-movie-desc="Máte rádi překvapení? Věříte dramaturgům kina Aero, že vás dokáží příjemně překvapit? Když přijmete na&amp;s" data-page-title="Aero naslepo – hraje se v kině Aero" data-projection="50303">Aero naslepo</div>
+</div>
+<div class="program__tags program__tags--kino-aero">
+<span class="program__tag" onclick="checkTagInput('English Friendly')">ENG</span>
+<span class="program__tag" onclick="checkTagInput('Naslepo')">
+                                            Naslepo</span>
+</div>
+</div>
+<div class="program__price">
+<span class="program__ticket program__ticket--zero">
+                                    Zdarma
+                                </span>
+<span class="program__running">Probíhá</span>
+</div>
+<script type="application/ld+json">
+                            {
+                                "@context": "https://schema.org",
+                                "@type": "Event",
+                                "name": "Aero naslepo",
+                                "description": "&quot;M&amp;aacute;te r&amp;aacute;di p\u0159ekvapen&amp;iacute;? V\u011b\u0159&amp;iacute;te dramaturg\u016fm kina Aero, \u017ee v&amp;aacute;s dok&amp;aacute;\u017e&amp;iacute; p\u0159&amp;iacute;jemn\u011b p\u0159ekvapit? Kdy\u017e p\u0159ijmete na&amp;scaron;i hru a zkus&amp;iacute;te &amp;bdquo;Aero naslepo&amp;ldquo;, nebudete do posledn&amp;iacute; chv&amp;iacute;le v\u011bd\u011bt, na jak&amp;yacute; film jste se vypravili. Zato budete m&amp;iacute;t jistotu, \u017ee zaplat&amp;iacute;te p\u0159esn\u011b takovou \u010d&amp;aacute;stku, jakou sami uzn&amp;aacute;te za vhodn&amp;eacute;. P\u0159edem toti\u017e neplat&amp;iacute;te nic.\r\n\r\nPo projekci pak dostanete mo\u017enost ocenit \u010derstv\u011b nabyt&amp;yacute; z&amp;aacute;\u017eitek \u010d&amp;aacute;stkou, kterou si sami ur\u010d&amp;iacute;te. A je&amp;scaron;t\u011b jednu jistotu m&amp;aacute;te &amp;ndash; pokud p\u0159ijdete a zjist&amp;iacute;te, \u017ee jste prom&amp;iacute;tan&amp;yacute; film u\u017e vid\u011bli, vykompenzujeme v&amp;aacute;m takovou ztr&amp;aacute;tu \u010dasu jedn&amp;iacute;m pivem zdarma. Jdete do toho?\r\n\r\nVstupenky na Aero Naslepo se vyd&amp;aacute;vaj&amp;iacute; na pokladn&amp;aacute;ch kin Aero, Oko, Sv\u011btozor v po\u010dtu max. 6 ks na osobu.&quot;",
+                                "url": "https://kinoaero.cz/?projection=50303",
+                                "eventStatus": "EventScheduled",
+                                "eventAttendanceMode": "OfflineEventAttendanceMode",
+                                "location": {
+                                    "@type": "Place",
+                                    "name": "Kino Aero",
+                                    "address": {
+                                        "@type": "PostalAddress",
+                                        "addressLocality": "Prague, Czechia",
+                                        "addressRegion": "Prague 3",
+                                        "streetAddress": "Biskupcova 31",
+                                        "postalCode": "130 00"
+                                    }
+                                },
+                                "director":"???",
+                                "duration":"PT2H0M",
+                                "inLanguage": "",
+                                "organizer": {
+                                    "@type": "Organization",
+                                    "name": "Kino Aero",
+                                    "email": "info@kinoaero.cz",
+                                    "phone": "+420 608 330 088",
+                                    "address": {
+                                        "@type": "PostalAddress",
+                                        "addressLocality": "Prague, Czechia",
+                                        "addressRegion": "Prague 3",
+                                        "streetAddress": "Biskupcova 31",
+                                        "postalCode": "130 00"
+                                    }
+                                },
+                                "startDate":"2026-08-05T20:30:00+02:00",
+                                "endDate":"2026-08-05T22:30:00+02:00",
+                                "image":"https://kinoaero.cz/uploads/images/movies/2021/09/24/28a6125ad3f3bc6a23eb203337ad059b.jpg",
+                                "offers": {
+                                    "@type": "offer",
+                                    "url": "https://kinoaero.cz/?projection=50303",
+                                    "availability":"InStock",
+                                    "price": "0",
+                                    "priceCurrency": "czk"
+                                }
+                            }
+                        </script>
+</div>
+<div class="program__info-row">
+<div class="program__info-row-left">
+<div class="program__shared-hover program__shared-hover--kino-aero">
+<div class="program__info-row-left-top" data-bs-target="#projection-detail-modal" data-bs-toggle="modal" data-movie-desc="Patnáctiletému Johnovi (Robert Aramayo) se navždy změní život, když do něj náhlé propuknutí Tourettova syndromu přines" data-page-title="Přísahám, že za to nemůžu – hraje se v kině Aero" data-projection="52659">
+<div class="program__hour">13:30</div>
+<div class="program__place program__place--desktop">
+<span>Aero</span><br/>
+                                        Kinosál                                    </div>
+<div class="program__place program__place--mobile">
+<span>Aero</span><br/>
+</div>
+</div>
+<div class="program__movie-name" data-bs-target="#projection-detail-modal" data-bs-toggle="modal" data-movie-desc="Patnáctiletému Johnovi (Robert Aramayo) se navždy změní život, když do něj náhlé propuknutí Tourettova syndromu přines" data-page-title="Přísahám, že za to nemůžu – hraje se v kině Aero" data-projection="52659">Přísahám, že za to nemůžu</div>
+</div>
+<div class="program__tags program__tags--kino-aero">
+<span class="program__tag" onclick="checkTagInput('English Friendly')">ENG</span>
+<span class="program__tag" onclick="checkTagInput('Bio Senior')">
+                                            Bio Senior</span>
+</div>
+</div>
+<div class="program__price">
+<form action="https://tickets.colosseum.eu/hall" method="post">
+<input name="mrsid" type="hidden" value="389">
+<input name="eventid" type="hidden" value="4509208">
+<input name="successredirect" type="hidden" value="https://kinoaero.cz/?projection=52659">
+<input name="failedredirect" type="hidden" value="https://kinoaero.cz/?projection=52659">
+<input name="redirectaddtickets" type="hidden" value="https://kinoaero.cz/?projection=52659">
+<input name="language" type="hidden" value="cs">
+<button class="program__ticket program__ticket--kino-aero" type="submit">
+<svg style="enable-background:new 0 0 20 20;" version="1.1" viewbox="0 0 20 20" x="0px" xml:space="preserve" y="0px">
+<path d="M16.8,5.2l-0.4,0.4c-0.6,0.6-1.5,0.6-2,0c-0.3-0.3-0.4-0.6-0.4-1c0-0.4,0.2-0.7,0.4-1l0.4-0.4l-2.4-2.4L0.9,12.4l2.4,2.4
+        l0.4-0.4c0.6-0.5,1.5-0.5,2,0c0.3,0.3,0.4,0.6,0.4,1c0,0.4-0.2,0.7-0.4,1l-0.4,0.4l2.4,2.4L19.2,7.6L16.8,5.2z M6.6,13.4
+        c-0.9-0.9-2.3-1-3.3-0.4l-0.6-0.6l6-6l5,5l-6,6L7,16.7C7.6,15.7,7.5,14.3,6.6,13.4z M13.4,6.6c0.9,0.9,2.3,1,3.3,0.4l0.6,0.6
+        l-2.9,2.9l-5-5l2.9-2.9L13,3.3C12.4,4.3,12.6,5.7,13.4,6.6z" fill="currentColor"></path>
+</svg>
+<span>90 Kč</span>
+</button>
+</input></input></input></input></input></input></form>
+<span class="program__running">Probíhá</span>
+</div>
+<script type="application/ld+json">
+                            {
+                                "@context": "https://schema.org",
+                                "@type": "Event",
+                                "name": "Přísahám, že za to nemůžu",
+                                "description": "&quot;Patn&amp;aacute;ctilet&amp;eacute;mu Johnovi (Robert Aramayo) se nav\u017edy zm\u011bn&amp;iacute; \u017eivot, kdy\u017e do n\u011bj n&amp;aacute;hl&amp;eacute; propuknut&amp;iacute; Tourettova syndromu p\u0159inese nekontrolovateln&amp;eacute; hlasov&amp;eacute; a t\u011blesn&amp;eacute; tiky. D&amp;iacute;ky tomu se dost&amp;aacute;v&amp;aacute; do konflikt\u016f a izolace. Stud mu br&amp;aacute;n&amp;iacute; navazovat vztahy, zat&amp;iacute;mco okoln&amp;iacute; sv\u011bt jeho onemocn\u011bn&amp;iacute; t&amp;eacute;m\u011b\u0159 nezn&amp;aacute; a nech&amp;aacute;pe.\r\n\r\nBritsk&amp;yacute; film P\u0159&amp;iacute;sah&amp;aacute;m, \u017ee za to nem\u016f\u017eu je nato\u010den&amp;yacute; podle skute\u010dn&amp;eacute;ho p\u0159&amp;iacute;b\u011bhu Johna Davidsona. Vypr&amp;aacute;v&amp;iacute; intimn&amp;iacute; a siln&amp;yacute; p\u0159&amp;iacute;b\u011bh o jeho zpo\u010d&amp;aacute;tku bezstarostn&amp;eacute;m dosp&amp;iacute;v&amp;aacute;n&amp;iacute; ukon\u010den&amp;eacute;m drsn&amp;yacute;m odcizen&amp;iacute;m, kdy je odm&amp;iacute;t&amp;aacute;n nech&amp;aacute;paj&amp;iacute;c&amp;iacute;m okoln&amp;iacute;m sv\u011btem a t&amp;aacute;pav\u011b hled&amp;aacute; vlastn&amp;iacute; \u017eivot. Johnovo setk&amp;aacute;n&amp;iacute; s Dottie (Maxine Peake), energickou matkou b&amp;yacute;val&amp;eacute;ho spolu\u017e&amp;aacute;ka mu otev\u0159e novou cestu do sv\u011bta, ve kter&amp;eacute;m nach&amp;aacute;z&amp;iacute; podporu, porozum\u011bn&amp;iacute; a odvahu \u010delit vlastn&amp;iacute;mu \u017eivotu a osudu. D&amp;iacute;ky tomuto vztahu se jeho stud a izolace m\u011bn&amp;iacute; v s&amp;iacute;lu, nach&amp;aacute;z&amp;iacute; i radost a schopnost \u010dasto vtipn\u011b pou\u017e&amp;iacute;t sv&amp;eacute; posti\u017een&amp;iacute; k&amp;nbsp;osv\u011bt\u011b a pochopen&amp;iacute;. Mo\u017en&amp;aacute; si toho v&amp;scaron;imne i britsk&amp;aacute; kr&amp;aacute;lovna.&quot;",
+                                "url": "https://kinoaero.cz/?projection=52659",
+                                "eventStatus": "EventScheduled",
+                                "eventAttendanceMode": "OfflineEventAttendanceMode",
+                                "location": {
+                                    "@type": "Place",
+                                    "name": "Kino Aero",
+                                    "address": {
+                                        "@type": "PostalAddress",
+                                        "addressLocality": "Prague, Czechia",
+                                        "addressRegion": "Prague 3",
+                                        "streetAddress": "Biskupcova 31",
+                                        "postalCode": "130 00"
+                                    }
+                                },
+                                "director":"Kirk Jones",
+                                "duration":"PT2H1M",
+                                "inLanguage": "en",
+                                "organizer": {
+                                    "@type": "Organization",
+                                    "name": "Kino Aero",
+                                    "email": "info@kinoaero.cz",
+                                    "phone": "+420 608 330 088",
+                                    "address": {
+                                        "@type": "PostalAddress",
+                                        "addressLocality": "Prague, Czechia",
+                                        "addressRegion": "Prague 3",
+                                        "streetAddress": "Biskupcova 31",
+                                        "postalCode": "130 00"
+                                    }
+                                },
+                                "startDate":"2026-08-06T13:30:00+02:00",
+                                "endDate":"2026-08-06T15:31:00+02:00",
+                                "image":"https://kinoaero.cz/uploads/images/movies/2026/05/21/b59863b6bd52f3207ae60de7d1df99cf.jpg",
+                                "offers": {
+                                    "@type": "offer",
+                                    "url": "https://kinoaero.cz/?projection=52659",
+                                    "availability":"InStock",
+                                    "price": "90",
+                                    "priceCurrency": "czk"
+                                }
+                            }
+                        </script>
+</div>
+</div>

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,4 +1,27 @@
-from kino.scraper import parse_country, parse_duration, parse_time_texts, parse_year
+from datetime import datetime
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+from kino.models import AeroScreening, Cinema, Screening
+from kino.scraper import (
+    PRAGUE_TZ,
+    csfd_film_id,
+    pair,
+    parse_aero_csfd_id,
+    parse_aero_program,
+    parse_country,
+    parse_duration,
+    parse_time_texts,
+    parse_year,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fixture(name: str) -> BeautifulSoup:
+    return BeautifulSoup((FIXTURES / name).read_text(), "html.parser")
 
 
 def test_parse_year():
@@ -51,3 +74,85 @@ def test_parse_country_multiple():
         Česko / Slovinsko / Polsko / Slovensko / Chorvatsko / Francie \n2025  110 min \n\n\t\t\t\t\t\t
     """
     assert parse_country(text) == "Česko"
+
+
+def test_csfd_film_id():
+    assert csfd_film_id("https://www.csfd.cz/film/1703542-title/prehled/") == "1703542"
+    assert csfd_film_id("https://www.csfd.cz/film/1703542") == "1703542"
+
+
+def test_csfd_film_id_missing():
+    assert csfd_film_id("https://kinoaero.cz/?projection=50303") is None
+
+
+def test_parse_aero_program():
+    program = parse_aero_program(fixture("aero_program.html"))
+    projections = [projection for projection, _ in program]
+    titles = [screening["title"] for _, screening in program]
+    assert projections == ["50303", "52659"]
+    assert titles == ["Aero naslepo", "Přísahám, že za to nemůžu"]
+    assert program[0][1] == {
+        "title": "Aero naslepo",
+        "screening_url": "https://kinoaero.cz/?projection=50303",
+        "starts_at": "2026-08-05T20:30:00+02:00",
+        "ends_at": "2026-08-05T22:30:00+02:00",
+    }
+
+
+def test_parse_aero_csfd_id():
+    assert parse_aero_csfd_id(fixture("aero_film.html")) == "1703542"
+
+
+def test_parse_aero_csfd_id_missing():
+    assert parse_aero_csfd_id(fixture("aero_film_no_csfd.html")) is None
+
+
+def screening(**kwargs) -> Screening:
+    return Screening(
+        cinema=Cinema.AERO,
+        title="Film",
+        film_url="https://www.csfd.cz/film/111-film/prehled/",
+        year=2026,
+        country="USA",
+        starts_at=datetime(2026, 8, 6, 18, 0, tzinfo=PRAGUE_TZ),
+        ends_at=datetime(2026, 8, 6, 20, 0, tzinfo=PRAGUE_TZ),
+        rating=80,
+        **kwargs,
+    )
+
+
+def aero_item(**kwargs) -> dict:
+    return {
+        "title": "Film",
+        "screening_url": "https://kinoaero.cz/?projection=1",
+        "starts_at": "2026-08-06T18:00:00+02:00",
+        "ends_at": "2026-08-06T20:00:00+02:00",
+        "csfd_id": "111",
+        **kwargs,
+    }
+
+
+def test_pair_keeps_base_when_already_present():
+    # Same film (CSFD id 111) at the same time is already in the base.
+    result = pair([screening()], [aero_item()])
+    assert result == [screening()]
+
+
+def test_pair_adds_missing_aero_screening():
+    result = pair([screening()], [aero_item(starts_at="2026-08-07T18:00:00+02:00")])
+    assert len(result) == 2
+    assert isinstance(result[1], AeroScreening)
+    assert result[1].emoji == "✈️"
+
+
+def test_pair_adds_naslepo_with_smiley():
+    result = pair([], [aero_item(title="Aero naslepo", csfd_id=None)])
+    assert len(result) == 1
+    assert result[0].emoji == "😎"
+
+
+def test_pair_adds_special_without_link_as_generic():
+    result = pair(
+        [], [aero_item(title="Dejvické divadlo: Ucpanej systém", csfd_id=None)]
+    )
+    assert result[0].emoji == "✈️"

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from bs4 import BeautifulSoup
 
 from kino.models import AeroScreening, Cinema, Screening
@@ -28,21 +29,19 @@ def test_parse_year():
     text = """
         Česko / Slovensko / Itálie \n2025  103 min \n\n\t\t\t\t\t\t
     """
+
     assert parse_year(text) == 2025
 
 
-def test_parse_duration_multiple_durations():
-    text = """
-        Itálie / USA \n1979  102 min (Alternativní 180 min)\n\n\t\t\t\t\t\t
-    """
-    assert parse_duration(text) == (102 + 180) // 2
-
-
-def test_missing_duration():
-    text = """
-        Velká Británie / Kypr \n2026 \n\n\t\t\t\t\t\t
-    """
-    assert parse_duration(text) == 140
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Itálie / USA \n1979  102 min (Alternativní 180 min)", (102 + 180) // 2),
+        ("Velká Británie / Kypr \n2026", 140),
+    ],
+)
+def test_parse_duration(text: str, expected: int):
+    assert parse_duration(text) == expected
 
 
 def test_parse_time_texts():
@@ -53,6 +52,7 @@ def test_parse_time_texts():
         17:30
         20:00
     """
+
     assert parse_time_texts(text) == [
         "10:00",
         "12:30",
@@ -62,62 +62,80 @@ def test_parse_time_texts():
     ]
 
 
-def test_parse_country():
-    text = """
-        USA \n2026  94 min \n\n\t\t\t\t\t\t
-    """
-    assert parse_country(text) == "USA"
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("USA \n2026  94 min", "USA"),
+        ("Česko / Slovinsko / Polsko / Slovensko / Francie \n2025  110 min", "Česko"),
+    ],
+)
+def test_parse_country(text: str, expected: str):
+    assert parse_country(text) == expected
 
 
-def test_parse_country_multiple():
-    text = """
-        Česko / Slovinsko / Polsko / Slovensko / Chorvatsko / Francie \n2025  110 min \n\n\t\t\t\t\t\t
-    """
-    assert parse_country(text) == "Česko"
-
-
-def test_csfd_film_id():
-    assert csfd_film_id("https://www.csfd.cz/film/1703542-title/prehled/") == "1703542"
-    assert csfd_film_id("https://www.csfd.cz/film/1703542") == "1703542"
-
-
-def test_csfd_film_id_missing():
-    assert csfd_film_id("https://kinoaero.cz/?projection=50303") is None
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://www.csfd.cz/film/1703542-title/prehled/", "1703542"),
+        ("https://www.csfd.cz/film/1703542", "1703542"),
+        ("https://kinoaero.cz/?projection=50303", None),
+    ],
+)
+def test_csfd_film_id(url: str, expected: str | None):
+    assert csfd_film_id(url) == expected
 
 
 def test_parse_aero_program():
     program = parse_aero_program(fixture("aero_program.html"))
-    projections = [projection for projection, _ in program]
-    titles = [screening["title"] for _, screening in program]
-    assert projections == ["50303", "52659"]
-    assert titles == ["Aero naslepo", "Přísahám, že za to nemůžu"]
-    assert program[0][1] == {
-        "title": "Aero naslepo",
-        "screening_url": "https://kinoaero.cz/?projection=50303",
-        "starts_at": "2026-08-05T20:30:00+02:00",
-        "ends_at": "2026-08-05T22:30:00+02:00",
-    }
+
+    assert program == [
+        (
+            "50303",
+            {
+                "title": "Aero naslepo",
+                "screening_url": "https://kinoaero.cz/?projection=50303",
+                "starts_at": "2026-08-05T20:30:00+02:00",
+                "ends_at": "2026-08-05T22:30:00+02:00",
+                "emoji": "😎",
+            },
+        ),
+        (
+            "52659",
+            {
+                "title": "Přísahám, že za to nemůžu",
+                "screening_url": "https://kinoaero.cz/?projection=52659",
+                "starts_at": "2026-08-06T13:30:00+02:00",
+                "ends_at": "2026-08-06T15:31:00+02:00",
+                "emoji": "✈️",
+            },
+        ),
+    ]
 
 
-def test_parse_aero_csfd_id():
-    assert parse_aero_csfd_id(fixture("aero_film.html")) == "1703542"
-
-
-def test_parse_aero_csfd_id_missing():
-    assert parse_aero_csfd_id(fixture("aero_film_no_csfd.html")) is None
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("aero_film.html", "1703542"),
+        ("aero_film_no_csfd.html", None),
+    ],
+)
+def test_parse_aero_csfd_id(name: str, expected: str | None):
+    assert parse_aero_csfd_id(fixture(name)) == expected
 
 
 def screening(**kwargs) -> Screening:
     return Screening(
-        cinema=Cinema.AERO,
-        title="Film",
-        film_url="https://www.csfd.cz/film/111-film/prehled/",
-        year=2026,
-        country="USA",
-        starts_at=datetime(2026, 8, 6, 18, 0, tzinfo=PRAGUE_TZ),
-        ends_at=datetime(2026, 8, 6, 20, 0, tzinfo=PRAGUE_TZ),
-        rating=80,
-        **kwargs,
+        **{
+            "cinema": Cinema.AERO,
+            "title": "Film",
+            "film_url": "https://www.csfd.cz/film/111-film/prehled/",
+            "year": 2026,
+            "country": "USA",
+            "starts_at": datetime(2026, 8, 6, 18, 0, tzinfo=PRAGUE_TZ),
+            "ends_at": datetime(2026, 8, 6, 20, 0, tzinfo=PRAGUE_TZ),
+            "rating": 80,
+            **kwargs,
+        }
     )
 
 
@@ -127,32 +145,43 @@ def aero_item(**kwargs) -> dict:
         "screening_url": "https://kinoaero.cz/?projection=1",
         "starts_at": "2026-08-06T18:00:00+02:00",
         "ends_at": "2026-08-06T20:00:00+02:00",
+        "emoji": "✈️",
         "csfd_id": "111",
         **kwargs,
     }
 
 
 def test_pair_keeps_base_when_already_present():
-    # Same film (CSFD id 111) at the same time is already in the base.
-    result = pair([screening()], [aero_item()])
-    assert result == [screening()]
+    base = screening(film_url="https://www.csfd.cz/film/111-film/prehled/")
+    aero = aero_item(csfd_id="111", starts_at="2026-08-06T18:00:00+02:00")
+
+    result = pair([base], [aero])
+
+    assert result == [base]
 
 
-def test_pair_adds_missing_aero_screening():
-    result = pair([screening()], [aero_item(starts_at="2026-08-07T18:00:00+02:00")])
+def test_pair_adds_screening_missing_from_base():
+    # Same film (CSFD id 111) but a screening time the base doesn't have.
+    aero = aero_item(csfd_id="111", starts_at="2026-08-07T18:00:00+02:00")
+
+    result = pair([screening()], [aero])
+
     assert len(result) == 2
     assert isinstance(result[1], AeroScreening)
-    assert result[1].emoji == "✈️"
 
 
-def test_pair_adds_naslepo_with_smiley():
-    result = pair([], [aero_item(title="Aero naslepo", csfd_id=None)])
-    assert len(result) == 1
-    assert result[0].emoji == "😎"
+@pytest.mark.parametrize("emoji", ["😎", "✈️"])
+def test_pair_keeps_aero_emoji(emoji: str):
+    # Screenings without a CSFD link are always added, keeping their emoji.
+    result = pair([], [aero_item(csfd_id=None, emoji=emoji)])
 
-
-def test_pair_adds_special_without_link_as_generic():
-    result = pair(
-        [], [aero_item(title="Dejvické divadlo: Ucpanej systém", csfd_id=None)]
-    )
-    assert result[0].emoji == "✈️"
+    assert result == [
+        AeroScreening(
+            cinema=Cinema.AERO,
+            title="Film",
+            screening_url="https://kinoaero.cz/?projection=1",
+            starts_at=datetime(2026, 8, 6, 18, 0, tzinfo=PRAGUE_TZ),
+            ends_at=datetime(2026, 8, 6, 20, 0, tzinfo=PRAGUE_TZ),
+            emoji=emoji,
+        )
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.4.2" },
-    { name = "crawlee", extras = ["beautifulsoup"], specifier = ">=1.8.2" },
+    { name = "crawlee", extras = ["beautifulsoup"], specifier = ">=1.8.3" },
     { name = "emoji-country-flag", specifier = ">=2.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ics", specifier = ">=0.7.3" },
@@ -327,7 +327,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-ruff", specifier = ">=0.5" },
-    { name = "ruff", specifier = ">=0.15.22" },
+    { name = "ruff", specifier = ">=0.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bring **all** items from the [kinoaero.cz](https://kinoaero.cz/) program into the calendar, not just *Aero naslepo*.

The scraper now merges the Kino Aero program with the existing CSFD base:

- Scrape CSFD for the base (unchanged).
- Scrape the whole Kino Aero program.
- If a screening is **already in the base** (same CSFD film id at the same time), keep it as is — full info and rating emoji.
- If a screening is **missing from the base**, add it.

## How pairing works

Each Aero screening's detail page (fetched via the `/api_film` endpoint) links to ČSFD when available, so pairing is just matching CSFD film ids. When the link is absent it's either *Aero naslepo* or a special event:

- **Aero naslepo** keeps its own 😎 smiley, as before.
- **Everything else** (special events, screenings without a ČSFD link, e.g. [projection 48495](https://kinoaero.cz/archiv?cinema=1&sort=sort-by-data&projection=48495)) gets a generic ✈️.

## Changes

- `models.py`: `SecretScreening` → `AeroScreening`, now carrying its own `emoji` (😎 for naslepo, ✈️ otherwise).
- `scraper.py`: full-program `aero` handler enqueues an `/api_film` lookup per screening; `aero_film` handler extracts the ČSFD id; `pair()` merges Aero screenings into the CSFD base, deduping by `(csfd_id, starts_at)`.
- Tests + fixtures for program parsing, ČSFD-id extraction (with and without link), and the pairing/dedup logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRwXpLkVpZZN3jw9dUiF9M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Aero cinema screenings, including regular and “Aero naslepo” events.
  * Aero screenings now display event-specific emojis in calendar entries.
  * Screening data is combined across cinema programs while preventing duplicate listings.
  * Unlinked special screenings are still included with appropriate details.

* **Bug Fixes**
  * Improved matching of Aero screenings with corresponding ČSFD film information.

* **Tests**
  * Expanded coverage for parsing, matching, deduplication, and screenings without linked film data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->