### PR TITLE
Reorganize cinema categories

### DIFF
--- a/src/kino/__main__.py
+++ b/src/kino/__main__.py
@@ -16,14 +16,12 @@ from kino.scraper import scrape
     "cinemas",
     default=[
         ("AERO", "kino.ics"),
-        ("ATLAS", "kino-extra.ics"),
-        ("EDISON", "kino.ics"),
+        ("EDISON", "kino-extra.ics"),
         ("FLORA", "kino-multi.ics"),
-        ("LUCERNA", "kino.ics"),
-        ("PILOTI", "kino-extra.ics"),
+        ("LUCERNA", "kino-extra.ics"),
         ("PRITOMNOST", "kino.ics"),
         ("SLOVANAK", "kino-multi.ics"),
-        ("SVETOZOR", "kino.ics"),
+        ("SVETOZOR", "kino-extra.ics"),
     ],
     help="Cinema specification",
     type=(


### PR DESCRIPTION
Edits the default cinema list in `src/kino/__main__.py`:

- Remove `("PILOTI", "kino-extra.ics")`
- Remove `("ATLAS", "kino-extra.ics")`
- Move `LUCERNA`, `EDISON`, and `SVETOZOR` from `kino.ics` to the extra category (`kino-extra.ics`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxKxrQWKWZtBKFfHNPo7pC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxKxrQWKWZtBKFfHNPo7pC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default cinema calendar mappings.
  * Removed calendar mappings for ATLAS and PILOTI.
  * Redirected EDISON, LUCERNA, and SVETOZOR calendars to `kino-extra.ics`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->